### PR TITLE
Improvements

### DIFF
--- a/src/Bertini.jl
+++ b/src/Bertini.jl
@@ -1,5 +1,6 @@
 module Bertini
 
+using Base.Filesystem
 import MultivariatePolynomials
 const MP = MultivariatePolynomials
 
@@ -8,7 +9,7 @@ export bertini
 function bertini(
     f::Vector{T};
     hom_variable_group = false,
-    file_path = pwd(),
+    file_path = mktempdir(),
     bertini_path = "",
     MPTYPE = nothing,
     MAXNEWTONITS = nothing,
@@ -18,6 +19,8 @@ function bertini(
 
     oldpath = pwd()
     cd(file_path)
+    println("File path: $(file_path)")
+
     bertini_input = ["CONFIG",
         "TrackType:$TrackType;"]
     MPTYPE != nothing && push!(bertini_input, "MPTYPE: $MPTYPE;")

--- a/src/Bertini.jl
+++ b/src/Bertini.jl
@@ -91,7 +91,7 @@ function bertini(
     end
 
     writedlm("input.txt", bertini_input, '\n')
-    run(`$(bertini_path)bertini input.txt`)
+    @time run(`$(bertini_path)bertini input.txt`)
     n_vars = length(MP.variables(f))
     if TrackType == 0
         finite_solutions = read_solution_file("finite_solutions", n_vars)

--- a/src/Bertini.jl
+++ b/src/Bertini.jl
@@ -89,50 +89,34 @@ function bertini(
 
     writedlm("input.txt", bertini_input, '\n')
     run(`$(bertini_path)bertini input.txt`)
+    n_vars = length(MP.variables(f))
     if TrackType == 0
-        if !hom_variable_group
-            A = readdlm("finite_solutions")
-            n_vars = length(MP.variables(f))
-            finite_solutions = [[A[(j+i),1] + im * A[(j+i),2] for i in 1:n_vars] for j in 1:A[1,1]]
-
-            A = readdlm("nonsingular_solutions")
-            n_vars = length(MP.variables(f))
-            nonsingular_solutions = [[A[(j+i),1] + im * A[(j+i),2] for i in 1:n_vars] for j in 1:A[1,1]]
-
-            A = readdlm("real_finite_solutions")
-            n_vars = length(MP.variables(f))
-            real_finite_solutions = [[A[(j+i),1] + im * A[(j+i),2] for i in 1:n_vars] for j in 1:A[1,1]]
-
-            A = readdlm("singular_solutions")
-            n_vars = length(MP.variables(f))
-            singular_solutions = [[A[(j+i),1] + im * A[(j+i),2] for i in 1:n_vars] for j in 1:A[1,1]]
-
-            cd(oldpath)
-            return Dict(
-                "finite_solutions" => finite_solutions,
-                "nonsingular_solutions" => nonsingular_solutions,
-                "real_finite_solutions" => real_finite_solutions,
-                "singular_solutions" => singular_solutions)
-        else
-            A = readdlm("nonsingular_solutions")
-            n_vars = length(MP.variables(f))
-            nonsingular_solutions = [[A[(j+i),1] + im * A[(j+i),2] for i in 1:n_vars] for j in 1:A[1,1]]
-
-            A = readdlm("real_solutions")
-            n_vars = length(MP.variables(f))
-            real_solutions = [[A[(j+i),1] + im * A[(j+i),2] for i in 1:n_vars] for j in 1:A[1,1]]
-
-            A = readdlm("singular_solutions")
-            n_vars = length(MP.variables(f))
-            singular_solutions = [[A[(j+i),1] + im * A[(j+i),2] for i in 1:n_vars] for j in 1:A[1,1]]
-
-            cd(oldpath)
-            return Dict(
-                "nonsingular_solutions" => nonsingular_solutions,
-                "real_solutions" => real_solutions,
-                "singular_solutions" => singular_solutions)
-        end
+        finite_solutions = read_solution_file("finite_solutions", n_vars)
+        nonsingular_solutions = read_solution_file("nonsingular_solutions", n_vars)
+        singular_solutions = read_solution_file("singular_solutions", n_vars)
+        real_finite_solutions = read_solution_file("real_finite_solutions", n_vars)
+        cd(oldpath)
+        return Dict(
+            "finite_solutions" => finite_solutions,
+            "nonsingular_solutions" => nonsingular_solutions,
+            "real_finite_solutions" => real_finite_solutions,
+            "singular_solutions" => singular_solutions)
+    else
+        nonsingular_solutions = read_solution_file("nonsingular_solutions", n_vars)
+        real_solutions = read_solution_file("real_solutions", n_vars)
+        singular_solutions = read_solution_file("singular_solutions", n_vars)
+        cd(oldpath)
+        return Dict(
+            "nonsingular_solutions" => nonsingular_solutions,
+            "real_solutions" => real_solutions,
+            "singular_solutions" => singular_solutions)
     end
-    cd(oldpath)
 end
+
+function read_solution_file(filename, n_vars)
+    A = readdlm(filename)
+    [[A[((j - 1)*n_vars + 1 + i),1] + im * A[((j - 1)*n_vars + 1 + i),2]
+      for i in 1:n_vars] for j in 1:A[1,1]]
+end
+
 end

--- a/src/Bertini.jl
+++ b/src/Bertini.jl
@@ -9,7 +9,7 @@ function bertini(
     f::Vector{T};
     hom_variable_group = false,
     file_path = pwd(),
-    bertini_path = "./",
+    bertini_path = "",
     MPTYPE = nothing,
     MAXNEWTONITS = nothing,
     ENDGAMEBDRY = nothing,
@@ -83,7 +83,7 @@ function bertini(
     if file_path != "" && file_path[end] != '/'
         file_path = string(file_path, "/")
     end
-    if bertini_path[end] != '/'
+    if !isempty(bertini_path) && bertini_path[end] != '/'
         bertini_path = string(bertini_path, "/")
     end
 

--- a/src/Bertini.jl
+++ b/src/Bertini.jl
@@ -10,12 +10,22 @@ function bertini(
     hom_variable_group = false,
     file_path = pwd(),
     bertini_path = "./",
+    MPTYPE = nothing,
+    MAXNEWTONITS = nothing,
+    ENDGAMEBDRY = nothing,
+    ENDGAMENUM = nothing,
     TrackType = 0) where {T <: MP.AbstractPolynomialLike}
 
     oldpath = pwd()
     cd(file_path)
+    bertini_input = ["CONFIG",
+        "TrackType:$TrackType;"]
+    MPTYPE != nothing && push!(bertini_input, "MPTYPE: $MPTYPE;")
+    ENDGAMEBDRY != nothing && push!(bertini_input, "ENDGAMEBDRY: $ENDGAMEBDRY;")
+    ENDGAMENUM != nothing && push!(bertini_input, "ENDGAMENUM: $ENDGAMENUM;")
+    MAXNEWTONITS != nothing && push!(bertini_input, "MAXNEWTONITS: $MAXNEWTONITS;")
+    push!(bertini_input, "END;", "INPUT")
 
-    bertini_input = ["CONFIG";  "TrackType:$TrackType;"; "END;"; "INPUT"]
     if hom_variable_group
         f_vars = "hom_variable_group "
     else


### PR DESCRIPTION
Here are a bunch of improvements and fixes:
* I added some Bertini configuration parameters like `MPTYPE`.
* I fixed the reading of the solutions from the files. Previously you read the wrong solutions. Assume
`n_vars=5` and we have 4 solutions. The correct thing would be to read lines 2 to 6, 7 to 11 etc. But so far we read 2 to 6, 3 to 7, etc.
* The default path to look for bertini is now the global path. I.e. if you can run bertini from your shell
`bertini ...` from anywhere then this will be used. The easiest thing would be to add a symlink to `/usr/local/bin` with
```
ln -s <absolute path to bertini> /usr/local/bin
```
* The bertini files are now generated in a temporary directory and the path is printed at the beginning.